### PR TITLE
Update README + change command line description for `--pathLog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ Add to build hook :
 ```
     hook:
         build: |
-            mkdir bin
-            curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
-            curl -fsSL https://github.com/upsun/scalsun/releases/download/v0.3.3/scalsun-v0.3.3-linux-amd64.tar.gz | tar -xzf - -c bin
+            curl -fsS https://raw.githubusercontent.com/upsun/snippets/main/src/install-upsun-tool.sh | bash /dev/stdin "scalsun"
+
 ```
 
 Add cron task every minute :
@@ -48,7 +47,7 @@ Usage of scalsun:
       --max_mem_usage_downscale float   Maximum memory usage in % (for downscale event only) (default 20)
   -v, --verbose                         Enable verbose mode
   -s, --silent                          Enable silent mode
-      --pathLog string                  Define Path of Log file (default "./")
+      --pathLog string                  Define Path of Log file (default "/var/log/")
 ```
 
 #### Samples

--- a/cmd/scaling-instance.go
+++ b/cmd/scaling-instance.go
@@ -27,7 +27,7 @@ func init() {
 
 	flag.BoolVarP(&app.Args.Verbose, "verbose", "v", false, "Enable verbose mode")
 	flag.BoolVarP(&app.Args.Silent, "silent", "s", false, "Enable silent mode")
-	flag.StringVarP(&app.Args.PathLog, "pathLog", "", "./", "Define Path of Log file")
+	flag.StringVarP(&app.Args.PathLog, "pathLog", "", "/var/log/", "Define Path of Log file")
 
 	flag.CommandLine.SortFlags = false
 	flag.Parse()


### PR DESCRIPTION
README: change installation guide to use install-upsun-tool.sh 

This script is generic enough to use it for later tools. 
Usage is: 
```
curl -fsS https://raw.githubusercontent.com/upsun/snippets/main/src/install-upsun-tool.sh | bash /dev/stdin "scalsun"
```
and `scalsun` is the private repos in the [Upsun](https://github.com/upsun/) that need to be installed in the `/app/bin` directory. 

ps: I also change the command line description to reflect default pathlog to `/var/log` (cc @Theosakamg ) 